### PR TITLE
Modified driver.csh with cleanups and documenting

### DIFF
--- a/run_mpas.csh
+++ b/run_mpas.csh
@@ -93,13 +93,13 @@ cd $rundir
 # Set boundary condition directory if regional
 # ----------------------------------------------
 if ( $MPAS_REGIONAL == .true. || $MPAS_REGIONAL == true ) then
-   set lbc_dir = ${MPAS_INIT_OUTPUT_DIR_TOP}/${DATE}/ens_${mem}
+   set lbc_dir = ${MPAS_INIT_DIR}/${DATE}/ens_${mem}
 endif
 
 # ----------------------------------------------
 # Get the initial conditions
 # ---------------------------------------------- 
-set mpas_ics = ${MPAS_INIT_OUTPUT_DIR_TOP}/${DATE}/ens_${mem}/init.nc # This is the only input file needed
+set mpas_ics = ${MPAS_INIT_DIR}/${DATE}/ens_${mem}/init.nc # This is the only input file needed
 
 set pp = ( $mpas_ics ) # array incase you want to add other files to look for
 foreach p ( $pp )
@@ -113,7 +113,7 @@ ln -sf $mpas_ics ./init.nc # link the initial conditions to the working director
 
 # If true, we want MPAS to look for a surface stream that reads a file with external sst/xice
 if ( $update_sst == .true. || $update_sst == true ) then
-   set sst_fname = ${MPAS_INIT_OUTPUT_DIR_TOP}/${DATE}/ens_${mem}/sfc_update.nc
+   set sst_fname = ${MPAS_INIT_DIR}/${DATE}/ens_${mem}/sfc_update.nc
    if ( -e $sst_fname ) then
       ln -sf $sst_fname  ./sfc_update.nc
    else
@@ -140,6 +140,9 @@ if ( -e $soundings_file ) ln -sf $soundings_file ./sounding_locations.txt
 $NAMELIST_TEMPLATE mpas # Output is ./namelist.atmosphere #atj modified
  
 $STREAMS_TEMPLATE mpas # Output is ./streams.atmosphere
+
+cp $SCRIPT_DIR/namelist.atmosphere .
+cp $SCRIPT_DIR/streams.atmosphere .
 
 if ( $MPAS_REGIONAL == .true. || $MPAS_REGIONAL == true ) ln -sf ${lbc_dir}/lbc*.nc .
 

--- a/run_mpas_init.csh
+++ b/run_mpas_init.csh
@@ -132,11 +132,11 @@ setenv num_ungrib_soil_levels_lbc  4
 
 ########
 
-set rundir = ${MPAS_INIT_OUTPUT_DIR_TOP}/${DATE}/ens_${mem} # make and go to the run directory
+set rundir = ${MPAS_INIT_DIR}/${DATE}/ens_${mem} # make and go to the run directory
 mkdir -p $rundir
+
 cd $rundir
 rm -f ./*.err # clean-up any error files from last time
-
 ln -sf ${MPAS_INIT_CODE_DIR}/init_atmosphere_model . # link executable
 
 #
@@ -323,6 +323,9 @@ foreach iter ( 3 4 5 )
 
    $STREAMS_TEMPLATE   mpas_init  
    set stream_file = streams.init_atmosphere # Output of above command
+
+   cp $SCRIPT_DIR/namelist.init_atmosphere .
+   cp $SCRIPT_DIR/streams.init_atmosphere .
 
    # -----------------------
    # Run MPAS initialization

--- a/run_mpassit.csh
+++ b/run_mpassit.csh
@@ -86,7 +86,7 @@ while ( $DATE <= $end_time)
    # ----------------------------------
    # Make and go to working directory
    # ----------------------------------
-   set rundir = $MPASSIT_OUTPUT_DIR_TOP/$start_init/ens_${mem}/${vhr}
+   set rundir = $MPASSIT_OUTPUT_DIR/$start_init/ens_${mem}/${vhr}
    mkdir -p $rundir
    cd $rundir
 
@@ -96,10 +96,10 @@ while ( $DATE <= $end_time)
    ln -sf ${MPASSIT_CODE_DIR}/bin/mpassit .
    ln -sf ${SCRIPT_DIR}/mpassit_files/* .
 
-   setenv grid_file $MPAS_INIT_OUTPUT_DIR_TOP/$start_init/ens_${mem}/init.nc
-   setenv hist_file $EXP_DIR_TOP/$start_init/ens_${mem}/history.${date_file_format}.nc
-   setenv diag_file $EXP_DIR_TOP/$start_init/ens_${mem}/diag.${date_file_format}.nc
-   setenv output_file $MPASSIT_OUTPUT_DIR_TOP/$start_init/ens_${mem}/proc.${date_file_format}.nc
+   setenv grid_file $MPAS_INIT_DIR/$start_init/ens_${mem}/init.nc
+   setenv hist_file $EXP_DIR/$start_init/ens_${mem}/history.${date_file_format}.nc
+   setenv diag_file $EXP_DIR/$start_init/ens_${mem}/diag.${date_file_format}.nc
+   setenv output_file $MPASSIT_OUTPUT_DIR/$start_init/ens_${mem}/proc.${date_file_format}.nc
 
    $NAMELIST_TEMPLATE mpassit
 

--- a/run_upp.csh
+++ b/run_upp.csh
@@ -100,7 +100,7 @@ while ( $DATE <= $end_time)
    # ----------------------------------
    # Make and go to working directory
    # ----------------------------------
-   set rundir = ${UPP_OUTPUT_DIR_TOP}/$start_init/ens_${mem}/${vhr}
+   set rundir = ${UPP_OUTPUT_DIR}/$start_init/ens_${mem}/${vhr}
    mkdir -p $rundir
    cd $rundir
 
@@ -113,7 +113,7 @@ while ( $DATE <= $end_time)
    ln -sf ${SCRIPT_DIR}/upp_files/ETAMPNEW_DATA nam_micro_lookup.dat
    ln -sf ${SCRIPT_DIR}/upp_files/ETAMPNEW_DATA.expanded_rain hires_micro_lookup.dat
 
-   setenv mpassit_file $MPASSIT_OUTPUT_DIR_TOP/$start_init/ens_${mem}/proc.${date_file_format}.nc
+   setenv mpassit_file $MPASSIT_OUTPUT_DIR/$start_init/ens_${mem}/proc.${date_file_format}.nc
 
    $NAMELIST_TEMPLATE upp
 


### PR DESCRIPTION
Preliminarily cleaned up driver.csh (haven't touched the qsub part yet), and ran workflow successfully for a regional simulation by executing from ungrid, initialization, to forecast. Variables in driver.csh were documented in[ this doc](https://docs.google.com/document/d/1EIQbFPVT8cp-_7fo7AoY7NzfG7eCCO9xe2tAjEyO7aU/edit?pli=1&tab=t.9rio1cj9vq34)

Note that I have to make the following changes to make these happen, which have to be improved based on suggestion from @willmayfield - work in progress.
1) Using Will’s model source code: /glade/campaign/ral/jntp/mayfield/mpas_stoch/merge/MPAS-Model_spptint, otherwise, run would crash at forecast step if using the latest MPAS-A code base due to something related to Thompson MP.
2) Adding a few lines in run_mpas_init.csh and run_mpas.csh for copying namelist* and streams* to the experiment directories. Without these added lines, both mpas_init and mpas_atm would fail...
attn: @KathrynNewman @willmayfield @michelleharrold @mkavulich @j-opatz 